### PR TITLE
Support latest Developer Edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        firefox: [ '84.0', 'latest-esr', 'latest' ]
+        firefox: [ '84.0', 'latest-beta', 'latest-devedition', 'latest-esr', 'latest' ]
     name: Firefox ${{ matrix.firefox }} sample
     steps:
       - name: Setup firefox

--- a/__test__/DownloadURL.test.ts
+++ b/__test__/DownloadURL.test.ts
@@ -57,6 +57,11 @@ describe("LatestDownloadURL", () => {
       `https://download.mozilla.org/?product=firefox-latest&os=linux64&lang=en-US`,
     ],
     [
+      LatestVersion.LATEST_DEVEDITION,
+      { os: OS.LINUX, arch: Arch.AMD64 },
+      `https://download.mozilla.org/?product=firefox-devedition-latest&os=linux64&lang=en-US`,
+    ],
+    [
       LatestVersion.LATEST_ESR,
       { os: OS.MACOS, arch: Arch.AMD64 },
       `https://download.mozilla.org/?product=firefox-esr-latest&os=osx&lang=en-US`,

--- a/__test__/DownloadURLFactory.test.ts
+++ b/__test__/DownloadURLFactory.test.ts
@@ -6,6 +6,8 @@ describe("DownloadURLFactory", () => {
   describe.each([
     ["80.0", ArchiveDownloadURL],
     ["latest", LatestDownloadURL],
+    ["latest-beta", LatestDownloadURL],
+    ["latest-devedition", LatestDownloadURL],
     ["latest-esr", LatestDownloadURL],
   ])("for version %s", (version, expected) => {
     test(`returns ${String(expected.name)}`, () => {

--- a/src/DownloadURL.ts
+++ b/src/DownloadURL.ts
@@ -69,6 +69,8 @@ export class LatestDownloadURL implements DownloadURL {
         return "firefox-latest";
       case LatestVersion.LATEST_BETA:
         return "firefox-beta-latest";
+      case LatestVersion.LATEST_DEVEDITION:
+        return "firefox-devedition-latest";
       case LatestVersion.LATEST_ESR:
         return "firefox-esr-latest";
     }

--- a/src/versions.ts
+++ b/src/versions.ts
@@ -1,4 +1,5 @@
 export const LatestVersion = {
+  LATEST_DEVEDITION: "latest-devedition",
   LATEST_BETA: "latest-beta",
   LATEST_ESR: "latest-esr",
   LATEST: "latest",
@@ -11,6 +12,7 @@ export const isLatestVersion = (version: string): version is LatestVersion => {
   return (
     version === LatestVersion.LATEST ||
     version === LatestVersion.LATEST_BETA ||
+    version === LatestVersion.LATEST_DEVEDITION ||
     version === LatestVersion.LATEST_ESR
   );
 };


### PR DESCRIPTION
Hi. Thanks for this action. It works great and it would be super useful for automated testing of Firefox extensions.

I added support for the latest Developer Edition here, which is useful for me because only Nightly and Developer Edition support installation of unsigned extensions.

Is this something you would consider merging?