### PR TITLE
Update Node.js

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,5 +6,5 @@ inputs:
     description: 'The Firefox version to install and use. Examples: 84.0, 84.0.1, latest-esr'
 
 runs:
-  using: 'node16'
+  using: 'node18'
   main: 'index.js'

--- a/action.yml
+++ b/action.yml
@@ -6,5 +6,5 @@ inputs:
     description: 'The Firefox version to install and use. Examples: 84.0, 84.0.1, latest-esr'
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'


### PR DESCRIPTION
closes https://github.com/browser-actions/setup-firefox/issues/346

`browser-actions/setup-firefox` uses Node.js 12.
However, it is already EOL.
Therefore, I update it to 18 (Active LTS).

For your information: https://github.com/nodejs/Release