### PR TITLE
feat: Output version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ steps:
   - run: firefox --version
 ```
 
+Use in the matrix:
 ```yaml
 jobs:
   build:
@@ -28,10 +29,13 @@ jobs:
     name: Firefox ${{ matrix.firefox }} sample
     steps:
       - name: Setup firefox
+        id: setup-firefox
         uses: browser-actions/setup-firefox@v1
         with:
           firefox-version: ${{ matrix.firefox }}
-      - run: firefox --version
+      - run: |
+          echo Installed firefox versions: ${{ steps.setup-firefox.outputs.firefox-version }}
+          firefox --version
 ```
 
 ## License

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,9 @@ author: "Shin'ya Ueoka"
 inputs:
   firefox-version:
     description: 'The Firefox version to install and use. Examples: 84.0, 84.0.1, latest-esr'
-
+outputs:
+  firefox-version:
+    description: 'The installed Firefox version. Useful when given a latest version.'
 runs:
   using: 'node16'
   main: 'index.js'

--- a/src/Installer.ts
+++ b/src/Installer.ts
@@ -23,7 +23,7 @@ const commonTestVersion = async (bin: string): Promise<string> => {
   const output = await exec.getExecOutput(`"${bin}"`, ["--version"]);
   if (output.exitCode !== 0) {
     throw new Error(
-      `firefox exit with exit code ${output.exitCode}: ${output.stderr}`
+      `firefox exits with status ${output.exitCode}: ${output.stderr}`
     );
   }
   if (!output.stdout.startsWith("Mozilla Firefox ")) {

--- a/src/Installer.ts
+++ b/src/Installer.ts
@@ -20,7 +20,7 @@ export default interface Installer {
 }
 
 const commonTestVersion = async (bin: string): Promise<string> => {
-  const output = await exec.getExecOutput(bin, ["--version"]);
+  const output = await exec.getExecOutput(`"${bin}"`, ["--version"]);
   if (output.exitCode !== 0) {
     throw new Error(
       `firefox exit with exit code ${output.exitCode}: ${output.stderr}`

--- a/src/Installer.ts
+++ b/src/Installer.ts
@@ -15,7 +15,22 @@ export type InstallSpec = {
 
 export default interface Installer {
   install(spec: InstallSpec): Promise<string>;
+
+  testVersion(bin: string): Promise<string>;
 }
+
+const commonTestVersion = async (bin: string): Promise<string> => {
+  const output = await exec.getExecOutput(bin, ["--version"]);
+  if (output.exitCode !== 0) {
+    throw new Error(
+      `firefox exit with exit code ${output.exitCode}: ${output.stderr}`
+    );
+  }
+  if (!output.stdout.startsWith("Mozilla Firefox ")) {
+    throw new Error(`firefox outputs unexpected results: ${output.stdout}`);
+  }
+  return output.stdout.trimEnd().replace("Mozilla Firefox ", "");
+};
 
 export class LinuxInstaller implements Installer {
   async install(spec: InstallSpec): Promise<string> {
@@ -52,6 +67,8 @@ export class LinuxInstaller implements Installer {
     core.info(`Successfully cached firefox ${version} to ${cachedDir}`);
     return cachedDir;
   }
+
+  testVersion = commonTestVersion;
 }
 
 export class MacOSInstaller implements Installer {
@@ -99,6 +116,8 @@ export class MacOSInstaller implements Installer {
     core.info(`Successfully cached firefox ${version} to ${cachedDir}`);
     return cachedDir;
   }
+
+  testVersion = commonTestVersion;
 }
 
 export class WindowsInstaller implements Installer {
@@ -145,4 +164,6 @@ export class WindowsInstaller implements Installer {
     }
     return true;
   }
+
+  testVersion = commonTestVersion;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ const run = async (): Promise<void> => {
       path.join(installDir, "firefox")
     );
     core.info(`Successfully setup firefox version ${actualVersion}`);
+    core.setOutput("firefox-version", actualVersion);
   } catch (error) {
     if (hasErrorMessage(error)) {
       core.setFailed(error.message);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
+import * as path from "path";
 import * as core from "@actions/core";
-import * as exec from "@actions/exec";
 import { getPlatform } from "./platform";
 import { LatestVersion } from "./versions";
 import InstallerFactory from "./InstallerFactory";
@@ -16,14 +16,15 @@ const run = async (): Promise<void> => {
 
     core.info(`Setup firefox ${version} (${language})`);
 
-    const installDir = await new InstallerFactory()
-      .create(platform)
-      .install({ version, platform, language });
+    const installer = new InstallerFactory().create(platform);
+    const installDir = await installer.install({ version, platform, language });
 
     core.addPath(installDir);
-    core.info(`Successfully setup firefox version ${version}`);
 
-    await exec.exec("firefox", ["--version"]);
+    const actualVersion = installer.testVersion(
+      path.join("installDir", "firefox")
+    );
+    core.info(`Successfully setup firefox version ${actualVersion}`);
   } catch (error) {
     if (hasErrorMessage(error)) {
       core.setFailed(error.message);

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,8 +21,8 @@ const run = async (): Promise<void> => {
 
     core.addPath(installDir);
 
-    const actualVersion = installer.testVersion(
-      path.join("installDir", "firefox")
+    const actualVersion = await installer.testVersion(
+      path.join(installDir, "firefox")
     );
     core.info(`Successfully setup firefox version ${actualVersion}`);
   } catch (error) {


### PR DESCRIPTION
Supports installed versions via `firefox-version` property on the action outputs.
This is useful for installing a latest version.
```yaml
steps:
  - name: Setup firefox
    id: setup-firefox
    uses: browser-actions/setup-firefox@v1
    with:
      firefox-version: latest
  - run: |
      echo Installed firefox versions: ${{ steps.setup-firefox.outputs.firefox-version }}
      firefox --version
```