### PR TITLE
feat: restore Windows support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,19 +43,13 @@ jobs:
           name: dist
 
       - uses: ./
-        # Latest version for windows is not currently supported
-        if: ${{ matrix.os != 'windows' }}
       - run: |
           firefox --version
-        if: ${{ matrix.os != 'windows' }}
       - uses: ./
-        # Latest version for windows is not currently supported
-        if: ${{ matrix.os != 'windows' }}
         with:
           firefox-version: latest-esr
       - run: |
           firefox --version
-        if: ${{ matrix.os != 'windows' }}
       - uses: ./
         with:
           firefox-version: "84.0"

--- a/__test__/DownloadURL.test.ts
+++ b/__test__/DownloadURL.test.ts
@@ -66,6 +66,16 @@ describe("LatestDownloadURL", () => {
       { os: OS.MACOS, arch: Arch.AMD64 },
       `https://download.mozilla.org/?product=firefox-esr-latest&os=osx&lang=en-US`,
     ],
+    [
+      LatestVersion.LATEST_ESR,
+      { os: OS.WINDOWS, arch: Arch.I686 },
+      `https://download.mozilla.org/?product=firefox-esr-latest&os=win&lang=en-US`,
+    ],
+    [
+      LatestVersion.LATEST_ESR,
+      { os: OS.WINDOWS, arch: Arch.AMD64 },
+      `https://download.mozilla.org/?product=firefox-esr-latest&os=win64&lang=en-US`,
+    ],
   ])("platform %s %s", (version, { os, arch }, expected) => {
     test(`returns URL ${expected}`, () => {
       const sut = new LatestDownloadURL(version, { os, arch }, "en-US");
@@ -74,8 +84,6 @@ describe("LatestDownloadURL", () => {
   });
 
   describe.each([
-    [OS.WINDOWS, Arch.AMD64],
-    [OS.WINDOWS, Arch.I686],
     [OS.MACOS, Arch.I686],
     [OS.MACOS, Arch.ARM64],
   ])("platform %s %s", (os, arch) => {

--- a/src/DownloadURL.ts
+++ b/src/DownloadURL.ts
@@ -84,11 +84,10 @@ export class LatestDownloadURL implements DownloadURL {
       return "linux";
     } else if (os === OS.LINUX && arch === Arch.AMD64) {
       return "linux64";
-      // TODO Unable to launch silent install on latest version for windows
-      // } else if (os === OS.WINDOWS && arch === Arch.I686) {
-      //   return "win";
-      // } else if (os === OS.WINDOWS && arch === Arch.AMD64) {
-      //   return "win64";
+    } else if (os === OS.WINDOWS && arch === Arch.I686) {
+      return "win";
+    } else if (os === OS.WINDOWS && arch === Arch.AMD64) {
+      return "win64";
     }
     throw new UnsupportedPlatformError({ os, arch }, this.version);
   }


### PR DESCRIPTION
This reverts commit 6828a285 and restores Windows support.

Windows support was apparently disabled in 6828a285. The only note left was "Unable to launch silent install on latest version for windows". After testing this on `windows-latest` (Windows Server 2022) and all Firefox versions currently tested in `build.yml`, this doesn't seem to be the case at all, and a silent install proceeds as expected and successfully ([workflow job run](https://github.com/ChlodAlejandro/setup-firefox/actions/runs/4663621819/jobs/8255113888), [real-life use](https://github.com/ChlodAlejandro/deputy/actions/runs/4663770628/jobs/8255414905)). Also testing this locally on a Hyper-V-hosted Windows VM, a silent install proceeds as expected, with no UAC prompt or Firefox Installer window interrupting the process.

I think it's safe to re-enable support for Windows, unless some other issue was the reason why this was disabled in the first place. In that case, I'll leave this PR up while a solution is found.

Closes #252. Blocks ChlodAlejandro/deputy#73.