### PR TITLE
feat: output installed binary path

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ jobs:
           firefox-version: ${{ matrix.firefox }}
       - run: |
           echo Installed firefox versions: ${{ steps.setup-firefox.outputs.firefox-version }}
-          firefox --version
+          ${{ steps.setup-firefox.outputs.firefox-path }} --version
 ```
 
 ## License

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,8 @@ inputs:
 outputs:
   firefox-version:
     description: 'The installed Firefox version. Useful when given a latest version.'
+  firefox-path:
+    description: 'The installed Firefox path.'
 runs:
   using: 'node16'
   main: 'index.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,11 +21,11 @@ const run = async (): Promise<void> => {
 
     core.addPath(installDir);
 
-    const actualVersion = await installer.testVersion(
-      path.join(installDir, "firefox"),
-    );
-    core.info(`Successfully setup firefox version ${actualVersion}`);
-    core.setOutput("firefox-version", actualVersion);
+    const installedBinPath = path.join(installDir, "firefox");
+    const installedVersion = await installer.testVersion(installedBinPath);
+    core.info(`Successfully setup firefox version ${installedVersion}`);
+    core.setOutput("firefox-version", installedVersion);
+    core.setOutput("firefox-path", installedBinPath);
   } catch (error) {
     if (hasErrorMessage(error)) {
       core.setFailed(error.message);


### PR DESCRIPTION
Close #359.  This change enables exposing installed firefox binary path via `outputs.firefox-path` parameter.