### PR TITLE
feat: Support windows 11 arm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,8 @@ jobs:
     needs: [build]
     strategy:
       matrix:
-        os: [ubuntu, macos, windows]
-    runs-on: ${{ matrix.os }}-latest
+        os: [ubuntu-latest, macos-latest, windows-latest, windows-11-arm]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/__test__/DownloadURL.test.ts
+++ b/__test__/DownloadURL.test.ts
@@ -107,6 +107,11 @@ describe("LatestDownloadURL", () => {
       { os: OS.WINDOWS, arch: Arch.AMD64 },
       "https://download.mozilla.org/?product=firefox-esr-latest&os=win64&lang=en-US",
     ],
+    [
+      LatestVersion.LATEST_ESR,
+      { os: OS.WINDOWS, arch: Arch.ARM64 },
+      "https://download.mozilla.org/?product=firefox-esr-latest&os=win64-aarch64&lang=en-US",
+    ],
   ])("platform %s %s", (version, { os, arch }, expected) => {
     test(`returns URL ${expected}`, () => {
       const sut = new LatestDownloadURL(version, { os, arch }, "en-US");

--- a/src/DownloadURL.ts
+++ b/src/DownloadURL.ts
@@ -124,6 +124,8 @@ export class LatestDownloadURL implements DownloadURL {
       return "win";
     } else if (os === OS.WINDOWS && arch === Arch.AMD64) {
       return "win64";
+    } else if (os === OS.WINDOWS && arch === Arch.ARM64) {
+      return "win64-aarch64";
     }
     throw new UnsupportedPlatformError({ os, arch }, this.version);
   }


### PR DESCRIPTION
The action now supports installing firefox on Windows 11 ARM.

```yaml
build-job:
  runs-on: windows-11-arm
  steps:
    - uses: browser-actions/setup-firefox@v1
      with:
        firefox-version: latest-esr
```