### PR TITLE
feat: Support Linux ARM64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
     needs: [build]
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, ubuntu-24.04-arm]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,8 @@ jobs:
       - name: Test default
         uses: ./
         id: test-default
-      - run: |
+      - name: Test default version
+        run: |
           firefox --version
           ${{ steps.test-default.outputs.firefox-path }} --version
       - name: Test latest-beta
@@ -48,25 +49,28 @@ jobs:
         with:
           firefox-version: latest-beta
         id: test-latest-beta
-      - run: |
+      - name: Test latest-beta version
+        run: |
           firefox --version
           ${{ steps.test-latest-beta.outputs.firefox-path }} --version
-      - name: Test 132.0
+      - name: Test 140.0
         uses: ./
         with:
-          firefox-version: "132.0"
-        id: test-132-0
-      - run: |
+          firefox-version: "140.0"
+        id: test-140
+      - name: Test 140.0 version
+        run: |
           firefox --version
-          ${{ steps.test-132-0.outputs.firefox-path }} --version
-      - name: Test devedition-132.0b1
+          ${{ steps.test-140.outputs.firefox-path }} --version
+      - name: Test devedition-140.0b1
         uses: ./
         with:
-          firefox-version: "devedition-132.0b1"
-        id: test-devedition-132-0b1
-      - run: |
+          firefox-version: "devedition-140.0b1"
+        id: test-devedition-140-0b1
+      - name: Test devedition-140.0b1 version
+        run: |
           firefox --version
-          ${{ steps.test-devedition-132-0b1.outputs.firefox-path }} --version
+          ${{ steps.test-devedition-140-0b1.outputs.firefox-path }} --version
 
   test-windows:
     needs: [build]
@@ -97,23 +101,23 @@ jobs:
         run: |
           firefox --version
           & "${{ steps.test-latest-beta.outputs.firefox-path }}" --version
-      - name: Test 132.0
+      - name: Test 140.0
         uses: ./
         with:
-          firefox-version: "132.0"
-        id: test-132-0
-      - name: Test 132.0 version
+          firefox-version: "140.0"
+        id: test-140
+      - name: Test 140.0 version
         shell: pwsh
         run: |
           firefox --version
-          & "${{ steps.test-132-0.outputs.firefox-path }}" --version
-      - name: Test devedition-132.0b1
+          & "${{ steps.test-140.outputs.firefox-path }}" --version
+      - name: Test devedition-140.0b1
         uses: ./
         with:
-          firefox-version: "devedition-132.0b1"
-        id: test-devedition-132-0b1
-      - name: Test devedition-132.0b1 version
+          firefox-version: "devedition-140.0b1"
+        id: test-devedition-140-0b1
+      - name: Test devedition-140.0b1 version
         shell: pwsh
         run: |
           firefox --version
-          & "${{ steps.test-devedition-132-0b1.outputs.firefox-path }}" --version
+          & "${{ steps.test-devedition-140-0b1.outputs.firefox-path }}" --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,14 +43,14 @@ jobs:
       - run: |
           firefox --version
           ${{ steps.test-default.outputs.firefox-path }} --version
-      - name: Test latest-esr
+      - name: Test latest-beta
         uses: ./
         with:
-          firefox-version: latest-esr
-        id: test-latest-esr
+          firefox-version: latest-beta
+        id: test-latest-beta
       - run: |
           firefox --version
-          ${{ steps.test-latest-esr.outputs.firefox-path }} --version
+          ${{ steps.test-latest-beta.outputs.firefox-path }} --version
       - name: Test 132.0
         uses: ./
         with:
@@ -87,16 +87,16 @@ jobs:
         run: |
           firefox --version
           & "${{ steps.test-default.outputs.firefox-path }}" --version
-      - name: Test latest-esr
+      - name: Test latest-beta
         uses: ./
         with:
-          firefox-version: latest-esr
-        id: test-latest-esr
-      - name: Test latest-esr version
+          firefox-version: latest-beta
+        id: test-latest-beta
+      - name: Test latest-beta version
         shell: pwsh
         run: |
           firefox --version
-          & "${{ steps.test-latest-esr.outputs.firefox-path }}" --version
+          & "${{ steps.test-latest-beta.outputs.firefox-path }}" --version
       - name: Test 132.0
         uses: ./
         with:

--- a/__test__/DownloadURL.test.ts
+++ b/__test__/DownloadURL.test.ts
@@ -15,6 +15,10 @@ describe("ArchiveDownloadURL", () => {
       "https://ftp.mozilla.org/pub/firefox/releases/134.0/linux-x86_64/en-US/firefox-134.0.tar.bz2",
     ],
     [
+      { os: OS.LINUX, arch: Arch.ARM64 },
+      "https://ftp.mozilla.org/pub/firefox/releases/134.0/linux-aarch64/en-US/firefox-134.0.tar.bz2",
+    ],
+    [
       { os: OS.MACOS, arch: Arch.AMD64 },
       "https://ftp.mozilla.org/pub/firefox/releases/134.0/mac/en-US/Firefox%20134.0.dmg",
     ],
@@ -76,6 +80,11 @@ describe("LatestDownloadURL", () => {
       LatestVersion.LATEST,
       { os: OS.LINUX, arch: Arch.AMD64 },
       "https://download.mozilla.org/?product=firefox-latest&os=linux64&lang=en-US",
+    ],
+    [
+      LatestVersion.LATEST,
+      { os: OS.LINUX, arch: Arch.ARM64 },
+      "https://download.mozilla.org/?product=firefox-latest&os=linux64-aarch64&lang=en-US",
     ],
     [
       LatestVersion.LATEST_DEVEDITION,

--- a/src/DownloadURL.ts
+++ b/src/DownloadURL.ts
@@ -52,6 +52,8 @@ export class ArchiveDownloadURL implements DownloadURL {
       return "linux-i686";
     } else if (os === OS.LINUX && arch === Arch.AMD64) {
       return "linux-x86_64";
+    } else if (os === OS.LINUX && arch === Arch.ARM64) {
+      return "linux-aarch64";
     } else if (os === OS.WINDOWS && arch === Arch.I686) {
       return "win32";
     } else if (os === OS.WINDOWS && arch === Arch.AMD64) {
@@ -120,6 +122,8 @@ export class LatestDownloadURL implements DownloadURL {
       return "linux";
     } else if (os === OS.LINUX && arch === Arch.AMD64) {
       return "linux64";
+    } else if (os === OS.LINUX && arch === Arch.ARM64) {
+      return "linux64-aarch64";
     } else if (os === OS.WINDOWS && arch === Arch.I686) {
       return "win";
     } else if (os === OS.WINDOWS && arch === Arch.AMD64) {


### PR DESCRIPTION
This PR adds support for Linux ARM64. Close #633.

```yaml
build-job:
  runs-on: ubuntu-24.04-arm
  steps:
    - uses: browser-actions/setup-firefox@v1
      with:
        firefox-version: latest-beta
```